### PR TITLE
tests:simple copilot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,22 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up DevContainer
+      uses: devcontainers/ci@v0.2
       with:
-        python-version: '3.10'
+        devcontainer-path: .devcontainer
 
     - name: Install Dependencies
       run: |
+        # Install dependencies inside the devcontainer
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install pytest pytest-cov
 
     - name: Run Tests
-      run: pytest --cov=timeseries_models --cov-report=xml
+      run: |
+        # Run tests inside the devcontainer
+        pytest --cov=timeseries_models --cov-report=xml
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,15 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v4
 
-    - name: Set up DevContainer
-      uses: devcontainers/ci@v0.2
-      with:
-        devcontainer-path: .devcontainer
 
     - name: Install Dependencies
       run: |
-        # Install dependencies inside the devcontainer
         python -m pip install --upgrade pip
+        pip install .
         pip install -r requirements.txt
-        pip install pytest pytest-cov
 
     - name: Run Tests
       run: |
-        # Run tests inside the devcontainer
         pytest --cov=timeseries_models --cov-report=xml
 
     - name: Upload Coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+
+    - name: Run Tests
+      run: pytest --cov=timeseries_models --cov-report=xml
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
         pip install -r requirements.txt
+        pip install .
+        
 
     - name: Run Tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 timeseries_models.egg-info
+.pytest_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ipykernel
 matplotlib
 pytest
 pytest-cov
+git+https://github.com/christiando/gaussian-toolbox@main#egg=gaussian_toolbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ipykernel
 matplotlib
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ipykernel
 matplotlib
 pytest
+pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,10 @@ install_requires =
    
 [options.packages.find]
 where=.
+
+
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/tests/test_observation_model.py
+++ b/tests/test_observation_model.py
@@ -1,0 +1,145 @@
+from jax import random
+from jax import numpy as jnp
+
+from timeseries_models.observation_model import LinearObservationModel, LSEMObservationModel, LRBFMObservationModel
+
+
+def test_linear_observation_model_init_eye():
+    model = LinearObservationModel(Dx=3, Dz=3)
+    assert model.Dx == 3
+    assert model.Dz == 3
+    assert jnp.array_equal(model.C, jnp.eye(3))
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.delta == 0
+
+def test_linear_observation_model_init_random():
+    key = random.PRNGKey(0)
+    model = LinearObservationModel(Dx=3, Dz=2, key=key)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.C.shape == (3, 2)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.delta == 0
+
+def test_linear_observation_model_init_noise():
+    model = LinearObservationModel(Dx=3, Dz=3, noise_x=2.0)
+    assert model.Dx == 3
+    assert model.Dz == 3
+    assert jnp.array_equal(model.C, jnp.eye(3))
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, 4.0 * jnp.eye(3))
+    assert model.delta == 0
+
+def test_linear_observation_model_init_delta():
+    model = LinearObservationModel(Dx=3, Dz=3, delta=1.0)
+    assert model.Dx == 3
+    assert model.Dz == 3
+    assert jnp.array_equal(model.C, jnp.eye(3))
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, 2.0 * jnp.eye(3))
+    assert model.delta == 1.0
+
+def test_lsem_observation_model_init():
+    model = LSEMObservationModel(Dx=3, Dz=2, Dk=4)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.lambda_W == 0.0
+
+def test_lsem_observation_model_init_noise():
+    model = LSEMObservationModel(Dx=3, Dz=2, Dk=4, noise_x=2.0)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, 4.0 * jnp.eye(3))
+    assert model.lambda_W == 0.0
+
+def test_lsem_observation_model_init_lambda_W():
+    model = LSEMObservationModel(Dx=3, Dz=2, Dk=4, lambda_W=0.5)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.lambda_W == 0.5
+
+def test_lsem_observation_model_init_random():
+    key = random.PRNGKey(0)
+    model = LSEMObservationModel(Dx=3, Dz=2, Dk=4, key=key)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.lambda_W == 0.0
+
+def test_lrbfm_observation_model_init():
+    model = LRBFMObservationModel(Dx=3, Dz=2, Dk=4)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.kernel_type == "isotropic"
+
+def test_lrbfm_observation_model_init_noise():
+    model = LRBFMObservationModel(Dx=3, Dz=2, Dk=4, noise_z=2.0)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, 4.0 * jnp.eye(3))
+    assert model.kernel_type == "isotropic"
+
+def test_lrbfm_observation_model_init_kernel_type_scalar():
+    model = LRBFMObservationModel(Dx=3, Dz=2, Dk=4, kernel_type="scalar")
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.kernel_type == "scalar"
+
+def test_lrbfm_observation_model_init_kernel_type_anisotropic():
+    model = LRBFMObservationModel(Dx=3, Dz=2, Dk=4, kernel_type="anisotropic")
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.kernel_type == "anisotropic"
+
+def test_lrbfm_observation_model_init_random():
+    key = random.PRNGKey(0)
+    model = LRBFMObservationModel(Dx=3, Dz=2, Dk=4, key=key)
+    assert model.Dx == 3
+    assert model.Dz == 2
+    assert model.Dk == 4
+    assert model.Dphi == 6
+    assert model.C.shape == (3, 6)
+    assert jnp.array_equal(model.d, jnp.zeros(3))
+    assert jnp.array_equal(model.Qx, jnp.eye(3))
+    assert model.kernel_type == "isotropic"
+
+

--- a/tests/test_state_model.py
+++ b/tests/test_state_model.py
@@ -1,0 +1,34 @@
+import pytest
+from jax import random
+from timeseries_models.state_model import LSEMStateModel, LRBFMStateModel
+
+import jax.numpy as jnp
+
+def test_LSEMStateModel_initialization():
+    model = LSEMStateModel(Dz=3, Dk=2)
+    assert model.Dz == 3
+    assert model.Dk == 2
+    assert model.Qz.shape == (3, 3)
+    assert model.A.shape == (3, 5)
+    assert model.b.shape == (3,)
+    assert model.W.shape == (2, 4)
+    
+def test_LSEMStateModel_initialization():
+    model = LSEMStateModel(Dz=3, Dk=2)
+    assert model.Dz == 3
+    assert model.Dk == 2
+    assert model.Qz.shape == (3, 3)
+    assert model.A.shape == (3, 5)
+    assert model.b.shape == (3,)
+    assert model.W.shape == (2, 4)
+
+def test_LRBFMStateModel_initialization():
+    model = LRBFMStateModel(Dz=3, Dk=2)
+    assert model.Dz == 3
+    assert model.Dk == 2
+    assert model.Qz.shape == (3, 3)
+    assert model.A.shape == (3, 5)
+    assert model.b.shape == (3,)
+    assert model.mu.shape == (2, 3)
+    assert model.length_scale.shape == (2, 3)
+

--- a/timeseries_models/observation_model.py
+++ b/timeseries_models/observation_model.py
@@ -708,7 +708,7 @@ class LRBFMObservationModel(LSEMObservationModel):
         self.Qx = noise_z**2 * jnp.eye(self.Dx)
         self.Lx = jnp.linalg.cholesky(self.Qx)
         key, subkey = random.split(key)
-        self.C = random.normal(subkey(self.Dx, self.Dphi))
+        self.C = random.normal(subkey, (self.Dx, self.Dphi))
         if self.Dx == self.Dz:
             self.C = self.C.at[:, : self.Dz].set(jnp.eye(self.Dx))
         else:


### PR DESCRIPTION
# Added some simple tests for state and observation model

This pull request includes several changes to the `timeseries_models` package, particularly focusing on adding and improving tests for observation and state models, as well as a minor fix in the observation model initialization. Additionally, it includes a configuration update for pytest.

### Improvements to testing:

* [`tests/test_observation_model.py`](diffhunk://#diff-8183becbb954ccb245519b6a71662cc808ce064fed0e78e26557f7e1e86b3ea2R1-R145): Added comprehensive tests for `LinearObservationModel`, `LSEMObservationModel`, and `LRBFMObservationModel` to ensure proper initialization and functionality.
* [`tests/test_state_model.py`](diffhunk://#diff-53f3d6303804ebb827d1aa4dc7791d75ca22ccd7cfd6342e14c6fb27cab16c28R1-R34): Added tests for `LSEMStateModel` and `LRBFMStateModel` to verify their initialization and properties.

### Configuration updates:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R30-R36): Added pytest configuration to specify test paths, file patterns, class patterns, and function patterns for running tests.

### Code fixes:

* [`timeseries_models/observation_model.py`](diffhunk://#diff-923fd50d3651890fcaf09c9b0c88768aead8ac27eb62234f6fccd108b4162fc4L711-R711): Fixed a bug in the initialization of the `C` matrix in the `__init__` method by correcting the argument passed to `random.normal`.